### PR TITLE
Optimize Lambda layer build to reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
-    "build:lambda": "rm -rf dist layer && nest build && mkdir -p layer/nodejs && cp package.json pnpm-lock.yaml layer/nodejs/ && cp -R prisma layer/nodejs/prisma && pnpm install --prod --frozen-lockfile --dir layer/nodejs && rm -rf layer/nodejs/prisma",
+    "build:lambda": "rm -rf dist layer && DATABASE_URL=${DATABASE_URL:-postgresql://postgres:postgres@localhost:5432/postgres} pnpm exec prisma generate && nest build && node scripts/prepare-layer.mjs && pnpm install --prod --dir layer/nodejs && rm -rf layer/nodejs/prisma layer/nodejs/pnpm-lock.yaml",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/scripts/prepare-layer.mjs
+++ b/scripts/prepare-layer.mjs
@@ -1,0 +1,103 @@
+import { promises as fs } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, '..');
+const layerRoot = join(projectRoot, 'layer');
+const layerNodeModulesDir = join(layerRoot, 'nodejs');
+
+const runtimeDependencies = [
+  '@nestjs/common',
+  '@nestjs/core',
+  '@nestjs/platform-express',
+  '@vendia/serverless-express',
+  '@prisma/client',
+  'axios',
+  'express',
+  'reflect-metadata',
+  'rxjs',
+];
+
+const packageJsonPath = join(projectRoot, 'package.json');
+const nodeModulesDir = join(projectRoot, 'node_modules');
+const prismaDir = join(projectRoot, 'prisma');
+
+async function pathExists(path) {
+  try {
+    await fs.access(path);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function readJSON(path) {
+  const file = await fs.readFile(path, 'utf8');
+  return JSON.parse(file);
+}
+
+async function resolveDependencyVersions(rootPackageJson) {
+  const dependencies = {};
+
+  for (const dependencyName of runtimeDependencies) {
+    const specifier = rootPackageJson.dependencies?.[dependencyName];
+
+    if (!specifier) {
+      console.warn(`⚠️  Skipping ${dependencyName} because it is not declared in package.json`);
+      continue;
+    }
+
+    const installedPackageJsonPath = join(nodeModulesDir, dependencyName, 'package.json');
+    let resolvedVersion = specifier;
+
+    if (await pathExists(installedPackageJsonPath)) {
+      const installedPackageJson = await readJSON(installedPackageJsonPath);
+      resolvedVersion = installedPackageJson.version;
+    } else if (/^[~^]/.test(resolvedVersion)) {
+      resolvedVersion = resolvedVersion.replace(/^[~^]/, '');
+    }
+
+    dependencies[dependencyName] = resolvedVersion;
+  }
+
+  return dependencies;
+}
+
+async function writeLayerPackageJson(dependencies) {
+  const layerPackageJson = {
+    name: 'nest-lambda-runtime',
+    private: true,
+    version: '1.0.0',
+    dependencies,
+  };
+
+  await fs.mkdir(layerNodeModulesDir, { recursive: true });
+  await fs.writeFile(
+    join(layerNodeModulesDir, 'package.json'),
+    `${JSON.stringify(layerPackageJson, null, 2)}\n`,
+    'utf8',
+  );
+}
+
+async function copyPrismaSchema() {
+  if (!(await pathExists(prismaDir))) {
+    return;
+  }
+
+  await fs.cp(prismaDir, join(layerNodeModulesDir, 'prisma'), {
+    recursive: true,
+  });
+}
+
+async function main() {
+  await fs.rm(layerRoot, { recursive: true, force: true });
+
+  const rootPackageJson = await readJSON(packageJsonPath);
+  const dependencies = await resolveDependencyVersions(rootPackageJson);
+
+  await writeLayerPackageJson(dependencies);
+  await copyPrismaSchema();
+}
+
+await main();


### PR DESCRIPTION
## Summary
- generate a minimal package manifest for the Lambda layer so only runtime dependencies are installed
- update the build:lambda script to run Prisma client generation with a fallback URL and reuse the new layer preparation script

## Testing
- `pnpm lint` *(fails: existing lint issues in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d26b869ad8832f9143f78d1551fcff